### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()


### PR DESCRIPTION
This PR does the following:
- Adds a `setup.py` so that setuptools can properly parse it during pip install
    - see the important admonition on: https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html

Currently attempting to install from DDRBot (https://github.com/cyberkitsune/DDRBot) results in:
```
Collecting pygroovestats from git+git://github.com/cyberkitsune/Pygroovestats@master#egg=pygroovestats (from -r Requirements.txt (line 13))
  Cloning git://github.com/cyberkitsune/Pygroovestats (to revision master) to /tmp/pip-install-2obttfrj/pygroovestats
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.7/tokenize.py", line 447, in open
        buffer = _builtin_open(filename, 'rb')
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-2obttfrj/pygroovestats/setup.py'

```
